### PR TITLE
Bump to 1.3.0, lock down lager version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+deps/*
+ebin/*.beam
+ebin/*.app

--- a/rebar.config
+++ b/rebar.config
@@ -9,5 +9,5 @@
 {reset_after_eunit, true}.
 
 {deps, [
-        {lager, ".*", {git, "git://github.com/basho/lager", {branch, "master"}}}
+        {lager, "1.2.2", {git, "git://github.com/basho/lager", {tag, "1.2.2"}}}
        ]}.

--- a/src/velvet.app.src
+++ b/src/velvet.app.src
@@ -2,7 +2,7 @@
 {application, velvet,
  [
   {description, "velvet"},
-  {vsn, "1.0.0"},
+  {vsn, "1.3.0"},
   {modules, []},
   {registered, []},
   {applications, [


### PR DESCRIPTION
Bump to 1.3.0, lock down lager version
Add `.gitignore`
