### PR TITLE
Add R16B01 compatibility

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{require_otp_vsn, "R14B0[234]|R15"}.
+{require_otp_vsn, "R14B0[234]|R15|R16"}.
 
 {cover_enabled, true}.
 

--- a/src/stanchion_auth.erl
+++ b/src/stanchion_auth.erl
@@ -87,13 +87,22 @@ request_signature(HttpVerb, RawHeaders, Path, KeyData) ->
            Date,
            BashoHeaders,
            Path],
-    base64:encode_to_string(
-      crypto:hmac(sha, KeyData, STS)).
+
+    %% This is for compatibility for R16B and R15B
+    %% R15B does not have crypto:hmac/3, which looks
+    %% newly added in R16B. in future crypto:hmac_final/1
+    %% will probably replaced with crypto:hmac/3
+    %% like crypto:hmac(sha, KeyData, STS)
+    Ctx = crypto:hmac_update(crypto:hmac_init(sha, KeyData), STS),
+    base64:encode_to_string(crypto:hmac_final(Ctx)).
 
 %% ===================================================================
 %% Internal functions
 %% ===================================================================
 
+%% TODO:
+%% can this be replaced with stanchion_auth:request_sinature/2?
+%% - which is included in velvet.
 signature(KeyData, RD) ->
     Headers = normalize_headers(get_request_headers(RD)),
     BashoHeaders = extract_basho_headers(Headers),
@@ -124,8 +133,14 @@ signature(KeyData, RD) ->
            Date,
            BashoHeaders,
            Resource],
-    base64:encode_to_string(
-      crypto:hmac(sha, KeyData, STS)).
+
+    %% This is for compatibility for R16B and R15B
+    %% R15B does not have crypto:hmac/3, which looks
+    %% newly added in R16B. in future crypto:hmac_final/1
+    %% will probably replaced with crypto:hmac/3
+    %% like crypto:hmac(sha, KeyData, STS)
+    Ctx = crypto:hmac_update(crypto:hmac_init(sha, KeyData), STS),
+    base64:encode_to_string(crypto:hmac_final(Ctx)).
 
 check_auth(PresentedSignature, CalculatedSignature) ->
     PresentedSignature == CalculatedSignature.

--- a/src/stanchion_auth.erl
+++ b/src/stanchion_auth.erl
@@ -88,21 +88,13 @@ request_signature(HttpVerb, RawHeaders, Path, KeyData) ->
            BashoHeaders,
            Path],
 
-    %% This is for compatibility for R16B and R15B
-    %% R15B does not have crypto:hmac/3, which looks
-    %% newly added in R16B. in future crypto:hmac_final/1
-    %% will probably replaced with crypto:hmac/3
-    %% like crypto:hmac(sha, KeyData, STS)
-    Ctx = crypto:hmac_update(crypto:hmac_init(sha, KeyData), STS),
-    base64:encode_to_string(crypto:hmac_final(Ctx)).
+    base64:encode_to_string(
+      stanchion_utils:sha_mac(KeyData, STS)).
 
 %% ===================================================================
 %% Internal functions
 %% ===================================================================
 
-%% TODO:
-%% can this be replaced with stanchion_auth:request_sinature/2?
-%% - which is included in velvet.
 signature(KeyData, RD) ->
     Headers = normalize_headers(get_request_headers(RD)),
     BashoHeaders = extract_basho_headers(Headers),
@@ -133,14 +125,8 @@ signature(KeyData, RD) ->
            Date,
            BashoHeaders,
            Resource],
-
-    %% This is for compatibility for R16B and R15B
-    %% R15B does not have crypto:hmac/3, which looks
-    %% newly added in R16B. in future crypto:hmac_final/1
-    %% will probably replaced with crypto:hmac/3
-    %% like crypto:hmac(sha, KeyData, STS)
-    Ctx = crypto:hmac_update(crypto:hmac_init(sha, KeyData), STS),
-    base64:encode_to_string(crypto:hmac_final(Ctx)).
+    base64:encode_to_string(
+      stanchion_utils:sha_mac(KeyData, STS)).
 
 check_auth(PresentedSignature, CalculatedSignature) ->
     PresentedSignature == CalculatedSignature.

--- a/src/stanchion_auth.erl
+++ b/src/stanchion_auth.erl
@@ -88,7 +88,7 @@ request_signature(HttpVerb, RawHeaders, Path, KeyData) ->
            BashoHeaders,
            Path],
     base64:encode_to_string(
-      crypto:sha_mac(KeyData, STS)).
+      crypto:hmac(sha, KeyData, STS)).
 
 %% ===================================================================
 %% Internal functions
@@ -125,7 +125,7 @@ signature(KeyData, RD) ->
            BashoHeaders,
            Resource],
     base64:encode_to_string(
-      crypto:sha_mac(KeyData, STS)).
+      crypto:hmac(sha, KeyData, STS)).
 
 check_auth(PresentedSignature, CalculatedSignature) ->
     PresentedSignature == CalculatedSignature.

--- a/src/stanchion_utils.erl
+++ b/src/stanchion_utils.erl
@@ -23,7 +23,7 @@
 -module(stanchion_utils).
 
 %% Public API
--export([get_admin_creds/0]).
+-export([get_admin_creds/0, sha_mac/2, md5/1]).
 
 %% @doc Return the credentials of the admin user
 -spec get_admin_creds() -> {ok, {string(), string()}} | {error, term()}.
@@ -41,3 +41,13 @@ get_admin_creds() ->
             _ = lager:warning("The admin user's key id has not been defined."),
             {error, key_id_undefined}
     end.
+
+-ifdef(new_hash).
+sha_mac(KeyData, STS) ->
+    crypto:hmac(sha, KeyData, STS).
+md5(Bin) -> crypto:hash(md5, Bin).
+-else.
+sha_mac(KeyData, STS) ->
+    crypto:sha_mac(KeyData, STS).
+md5(Bin) -> crypto:md5(Bin).
+-endif.

--- a/src/velvet.erl
+++ b/src/velvet.erl
@@ -391,7 +391,7 @@ request(Method, Url, Expect, ContentType, Headers, Body) ->
 %% @doc Calculate an MD5 hash of a request body.
 -spec content_md5(string()) -> string().
 content_md5(Body) ->
-    base64:encode_to_string(crypto:hash(md5, list_to_binary(Body))).
+    base64:encode_to_string(stanchion_utils:md5(list_to_binary(Body))).
 
 %% @doc Construct a MOSS authentication header
 -spec auth_header(atom(),

--- a/src/velvet.erl
+++ b/src/velvet.erl
@@ -391,7 +391,7 @@ request(Method, Url, Expect, ContentType, Headers, Body) ->
 %% @doc Calculate an MD5 hash of a request body.
 -spec content_md5(string()) -> string().
 content_md5(Body) ->
-    base64:encode_to_string(crypto:md5(list_to_binary(Body))).
+    base64:encode_to_string(crypto:hash(md5, list_to_binary(Body))).
 
 %% @doc Construct a MOSS authentication header
 -spec auth_header(atom(),


### PR DESCRIPTION
R16B recommends us using `crypto:hmac/3` which R15B03 does not have. For compatibility I adopted `crypto:hmac_init/2`, `update` and `final`.
