### PR TITLE
Add conditionals to Makefile for R16 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,19 @@ ERLANG_BIN       = $(shell dirname $(shell which erl))
 REBAR           ?= $(BASE_DIR)/rebar
 OVERLAY_VARS    ?=
 
+VSN := $(shell erl -eval 'io:format("~s~n", [erlang:system_info(otp_release)]), init:stop().' | grep 'R' | sed -e 's,R\(..\)B.*,\1,')
+NEW_HASH := $(shell expr $(VSN) \>= 16)
+
 .PHONY: rel deps test
 
 all: deps compile
 
 compile:
-	@./rebar compile
+ifeq ($(NEW_HASH),1)
+	@(./rebar compile -Dnew_hash)
+else
+	@(./rebar compile)
+endif
 
 deps:
 	@./rebar get-deps
@@ -27,7 +34,11 @@ distclean: clean
 	@rm -rf $(PKG_ID).tar.gz
 
 test: all
+ifeq ($(NEW_HASH),1)
+	@(./rebar skip_deps=true -Dnew_hash eunit)
+else
 	@./rebar skip_deps=true eunit
+endif
 
 APPS = kernel stdlib sasl erts ssl tools os_mon runtime_tools crypto inets \
 	xmerl webtool eunit syntax_tools compiler


### PR DESCRIPTION
Add conditionals to Makefile so that the project can be built standalone. This
accounts for a change in the Erlang crypto API between R15 and R16.
