### PR TITLE
change crypto usage in otp 17, while including it in rebar

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{require_otp_vsn, "R14B0[234]|R15|R16"}.
+{require_otp_vsn, "R14B0[234]|R15|R16|17"}.
 
 {cover_enabled, true}.
 

--- a/src/stanchion_utils.erl
+++ b/src/stanchion_utils.erl
@@ -48,6 +48,6 @@ sha_mac(KeyData, STS) ->
 md5(Bin) -> crypto:hash(md5, Bin).
 -else.
 sha_mac(KeyData, STS) ->
-    crypto:sha_mac(KeyData, STS).
-md5(Bin) -> crypto:md5(Bin).
+    crypto:hmac(sha, KeyData, STS).
+md5(Bin) -> crypto:hash(md5, Bin).
 -endif.


### PR DESCRIPTION
add support on otp 17, the default version in MacOS 10.9 Mavericks
