### PR TITLE
Feature/bump deps and versions

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,5 +9,5 @@
 {reset_after_eunit, true}.
 
 {deps, [
-        {lager, "2.0.3", {git, "git://github.com/basho/lager", {tag, "2.0.3"}}}
+        {lager, "2.*", {git, "git://github.com/basho/lager", {tag, "2.1.1"}}}
        ]}.

--- a/src/velvet.app.src
+++ b/src/velvet.app.src
@@ -2,7 +2,7 @@
 {application, velvet,
  [
   {description, "velvet"},
-  {vsn, "1.3.0"},
+  {vsn, git},
   {modules, []},
   {registered, []},
   {applications, [


### PR DESCRIPTION
Will tag this as 1.4.0, as descendant of 1.3.0. This is for https://github.com/basho/riak_cs/pull/1190 .
